### PR TITLE
Added timeout conf option

### DIFF
--- a/custom_components/bobcatminer/__init__.py
+++ b/custom_components/bobcatminer/__init__.py
@@ -28,7 +28,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     hass_data = dict(entry.data)
-    bobcat = Bobcat(miner_ip=hass_data[CONFIG_HOST], get_timeout=hass_data[CONFIG_TIMEOUT])
+    bobcat = Bobcat(
+        miner_ip=hass_data[CONFIG_HOST],
+        get_timeout=hass_data[CONFIG_TIMEOUT],
+        auto_connect=False)
 
     async def _update_method():
         """Get the latest data from Bobcat Miner."""

--- a/custom_components/bobcatminer/__init__.py
+++ b/custom_components/bobcatminer/__init__.py
@@ -44,7 +44,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _update_method():
         """Get the latest data from Bobcat Miner."""
         try:
-            return await hass.async_add_executor_job(bobcat.status_summary)
+            summary = await hass.async_add_executor_job(bobcat.status_summary)
+
+            # bobcatpy will return an empty dict if something went wrong, catch that
+            if not summary:
+                raise UpdateFailed("Failed to get any data from miner")
+
+            return summary
         except Error as err:
             raise UpdateFailed(f"Unable to fetch data: {err}") from err
 

--- a/custom_components/bobcatminer/__init__.py
+++ b/custom_components/bobcatminer/__init__.py
@@ -44,13 +44,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _update_method():
         """Get the latest data from Bobcat Miner."""
         try:
-            summary = await hass.async_add_executor_job(bobcat.status_summary)
-
-            # bobcatpy will return an empty dict if something went wrong, catch that
-            if not summary:
-                raise UpdateFailed("Failed to get any data from miner")
-
-            return summary
+            # bobcatpy will return dict with 'state' value set to unavailable
+            # if it has any exception, sensor.py will check this state and make
+            # the sensor unavailable if needed
+            return await hass.async_add_executor_job(bobcat.status_summary)
         except Error as err:
             raise UpdateFailed(f"Unable to fetch data: {err}") from err
 

--- a/custom_components/bobcatminer/__init__.py
+++ b/custom_components/bobcatminer/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONFIG_HOST, DOMAIN
+from .const import CONFIG_HOST, CONFIG_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     hass_data = dict(entry.data)
-    bobcat = Bobcat(hass_data[CONFIG_HOST])
+    bobcat = Bobcat(miner_ip=hass_data[CONFIG_HOST], get_timeout=hass_data[CONFIG_TIMEOUT])
 
     async def _update_method():
         """Get the latest data from Bobcat Miner."""

--- a/custom_components/bobcatminer/__init__.py
+++ b/custom_components/bobcatminer/__init__.py
@@ -33,6 +33,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         get_timeout=hass_data[CONFIG_TIMEOUT],
         auto_connect=False)
 
+    try:
+        if bobcat.ping() != 0:
+            _LOGGER.error('Bobcat failed ping() tests')
+            return False
+    except:
+        _LOGGER.error('Bobcat raised exception during ping() test')
+        return False
+
     async def _update_method():
         """Get the latest data from Bobcat Miner."""
         try:

--- a/custom_components/bobcatminer/config_flow.py
+++ b/custom_components/bobcatminer/config_flow.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 STEP_MINER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONFIG_HOST): cv.string,
-        vol.Optional(CONFIG_TIMEOUT, default=5): cv.positive_int,
+        vol.Optional(CONFIG_TIMEOUT, default=20): cv.positive_int,
     }
 )
 
@@ -32,7 +32,6 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     # Test the connection to the miner
-    # __init__ will call ping() for us, but only prints...
     def _validate(host, timeout):
         miner = Bobcat(
             miner_ip=host,

--- a/custom_components/bobcatminer/config_flow.py
+++ b/custom_components/bobcatminer/config_flow.py
@@ -34,7 +34,10 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     # Test the connection to the miner
     # __init__ will call ping() for us, but only prints...
     def _validate(host, timeout):
-        miner = Bobcat(miner_ip=host, get_timeout=timeout)
+        miner = Bobcat(
+            miner_ip=host,
+            get_timeout=timeout,
+            auto_connect=False)
 
         try:
             # Socket can still raise exception if the hostname doesn't resolve

--- a/custom_components/bobcatminer/config_flow.py
+++ b/custom_components/bobcatminer/config_flow.py
@@ -6,13 +6,14 @@ from typing import Any
 
 import voluptuous as vol
 
+from bobcat import Bobcat
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONFIG_HOST, DOMAIN
+from .const import CONFIG_HOST, CONFIG_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 STEP_MINER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONFIG_HOST): cv.string,
+        vol.Optional(CONFIG_TIMEOUT, default=5): cv.positive_int,
     }
 )
 
@@ -29,20 +31,24 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    # TODO validate the data can be used to set up a connection.
+    # Test the connection to the miner
+    # __init__ will call ping() for us, but only prints...
+    def _validate(host, timeout):
+        miner = Bobcat(miner_ip=host, get_timeout=timeout)
 
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data["username"], data["password"]
-    # )
+        try:
+            # Socket can still raise exception if the hostname doesn't resolve
+            socket_errno = miner.ping()
+        except:
+            raise CannotConnect
 
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
+        # Did it fail for any reason, like timeout?
+        if socket_errno != 0:
+            raise CannotConnect
 
-    # Return info that you want to store in the config entry.
+    await hass.async_add_executor_job(
+        _validate, data[CONFIG_HOST], data[CONFIG_TIMEOUT]
+    )
 
     return {"title": "Bobcat Miner"}
 

--- a/custom_components/bobcatminer/config_flow.py
+++ b/custom_components/bobcatminer/config_flow.py
@@ -77,8 +77,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception: %s", ex)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
             return self.async_create_entry(title=info["title"], data=user_input)

--- a/custom_components/bobcatminer/config_flow.py
+++ b/custom_components/bobcatminer/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from bobcat import Bobcat
+from bobcatpy import Bobcat
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
@@ -78,8 +78,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception: %s", ex)
             errors["base"] = "unknown"
         else:
             return self.async_create_entry(title=info["title"], data=user_input)

--- a/custom_components/bobcatminer/const.py
+++ b/custom_components/bobcatminer/const.py
@@ -3,3 +3,4 @@
 DOMAIN = "bobcatminer"
 
 CONFIG_HOST = "host"
+CONFIG_TIMEOUT = "timeout"

--- a/custom_components/bobcatminer/strings.json
+++ b/custom_components/bobcatminer/strings.json
@@ -4,8 +4,7 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "timeout": "[%key:common::config_flow::data::timeout%]"
         }
       }
     },

--- a/custom_components/bobcatminer/translations/en.json
+++ b/custom_components/bobcatminer/translations/en.json
@@ -12,8 +12,7 @@
             "user": {
                 "data": {
                     "host": "Host",
-                    "password": "Password",
-                    "username": "Username"
+                    "timeout": "Connection Timeout"
                 }
             }
         }


### PR DESCRIPTION
This PR allows the user to specify the timeout period for bobcatpy to use. The default of 5 seconds is failing on my instance.

It also adds validation steps into the config flow to better test connectivity at the earliest point (when user is adding it).

Also validates the response when getting status data, as the timeout caused an empty dict to return and HA was immediately failing due to hard coded key index (`animal`) without properly testing presence etc.